### PR TITLE
Add Playwright test for client search page

### DIFF
--- a/tests/e2e_tests/test_clients_search.py
+++ b/tests/e2e_tests/test_clients_search.py
@@ -1,0 +1,28 @@
+import pytest
+import allure
+
+from tests.base_test import BaseTest
+
+
+@allure.epic("Clients")
+@allure.feature("Clients search")
+class TestClientsSearch(BaseTest):
+
+    @pytest.mark.regression
+    @allure.id("052")
+    @allure.title("052. Search clients and check results")
+    @allure.description("Opens clients page, fills search form and verifies that search returns at least one record")
+    @allure.tag("E2E", "UI", "Positive")
+    def test_search_clients(self):
+        page = self.browser.new_page()
+        url = "https://stage-frontend-arm-ui.apps.stg-okd-lan.vsk.ru/clients"
+        page.goto(url)
+        if "clients" not in page.url():
+            page.wait_for_url("**/clients", timeout=120000)
+        page.get_by_label("ФИО").fill("Тест Тестов")
+        page.get_by_label("Год рождения").fill("2000")
+        page.get_by_placeholder("Выберите статус").click()
+        page.get_by_role("option").first().click()
+        page.get_by_role("button", name="Поиск").click()
+        rows = page.locator("tbody tr[tuitr]")
+        assert rows.count() > 0


### PR DESCRIPTION
## Summary
- add end-to-end test that searches for clients and verifies results

## Testing
- `pytest tests/e2e_tests/test_clients_search.py -q` *(fails: FileNotFoundError: Директория "resources" отсутствует в проекте! Создайте нужный каталог с конфигурационными файлами и запустите приложение заново!)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d95b57883299b92af5f6fb95265