### PR TITLE
Refactor client search test to use page objects

### DIFF
--- a/core/ui/elements/button.py
+++ b/core/ui/elements/button.py
@@ -1,0 +1,18 @@
+import allure
+from playwright.sync_api import Locator
+
+from core.ui.elements.base_elements import BaseElement
+
+
+class Button(BaseElement):
+    @property
+    def type_of(self) -> str:
+        return "button"
+
+    def get_locator(self, **kwargs) -> Locator:
+        return self.page.get_by_role("button", name=self.locator, exact=True)
+
+    def click(self, **kwargs) -> None:
+        with allure.step(f'Click {self.type_of} "{self.name}"'):
+            locator = self.get_locator(**kwargs)
+            locator.click()

--- a/core/ui/elements/table.py
+++ b/core/ui/elements/table.py
@@ -1,0 +1,14 @@
+import allure
+from core.ui.elements.base_elements import BaseElement
+
+
+class Table(BaseElement):
+    @property
+    def type_of(self) -> str:
+        return "table"
+
+    def should_have_records(self, **kwargs) -> None:
+        with allure.step(f'Check {self.type_of} "{self.name}" has records'):
+            locator = self.get_locator(**kwargs)
+            locator.first.wait_for(timeout=5000)
+            assert locator.count() > 0, f"{self.type_of} '{self.name}' has no records"

--- a/core/ui/elements/text_input.py
+++ b/core/ui/elements/text_input.py
@@ -1,0 +1,18 @@
+import allure
+from playwright.sync_api import Locator
+
+from core.ui.elements.base_elements import BaseElement
+
+
+class TextInput(BaseElement):
+    @property
+    def type_of(self) -> str:
+        return "input field"
+
+    def get_locator(self, **kwargs) -> Locator:
+        return self.page.get_by_label(self.locator, exact=True)
+
+    def fill(self, value: str, **kwargs) -> None:
+        with allure.step(f'Fill {self.type_of} "{self.name}" with "{value}"'):
+            locator = self.get_locator(**kwargs)
+            locator.fill(value)

--- a/core/ui/module/base_module.py
+++ b/core/ui/module/base_module.py
@@ -1,0 +1,10 @@
+from abc import ABC
+from playwright.sync_api import Page
+
+
+class BaseModule(ABC):
+    """Base class for page modules."""
+
+    def __init__(self, page: Page, name: str) -> None:
+        self.page = page
+        self.name = name

--- a/core/ui/module/clients_search_form.py
+++ b/core/ui/module/clients_search_form.py
@@ -1,0 +1,18 @@
+from core.ui.module.base_module import BaseModule
+from core.ui.elements.text_input import TextInput
+from core.ui.elements.button import Button
+from core.ui.elements.table import Table
+
+
+class ClientsSearchForm(BaseModule):
+    def __init__(self, page):
+        super().__init__(page, "Clients search form")
+        self.fio_input = TextInput(page, "ФИО", "ФИО")
+        self.birth_year_input = TextInput(page, "Год рождения", "Год рождения")
+        self.search_button = Button(page, "Поиск", "Поиск")
+        self.results_table = Table(page, "tbody tr[tuitr]", "Search results")
+
+    def search(self, fio: str, birth_year: str) -> None:
+        self.fio_input.fill(fio)
+        self.birth_year_input.fill(birth_year)
+        self.search_button.click()

--- a/core/ui/pages/base_page.py
+++ b/core/ui/pages/base_page.py
@@ -13,9 +13,9 @@ class BasePage(ABC):
 
     def open(self, **kwargs) -> Response | None:
         with allure.step(f'Открываем страницу {self._url}'):
-            page = self._page.goto(self._url, **kwargs)
-        expect(page).to_have_title(re.compile(self._title))
-        return page
+            response = self._page.goto(self._url, **kwargs)
+        expect(self._page).to_have_title(re.compile(self._title))
+        return response
 
     def refresh(self, **kwargs) -> Response | None:
         with allure.step(f'Обновляем страницу {self._url}'):

--- a/core/ui/pages/clients_page.py
+++ b/core/ui/pages/clients_page.py
@@ -1,0 +1,17 @@
+from core.ui.pages.base_page import BasePage
+from core.ui.module.clients_search_form import ClientsSearchForm
+
+
+class ClientsPage(BasePage):
+    _url: str = "https://stage-frontend-arm-ui.apps.stg-okd-lan.vsk.ru/clients"
+    _title: str = "ВСК"
+
+    def __init__(self, page):
+        super().__init__(page)
+        self.search_form = ClientsSearchForm(page)
+
+    def search_clients(self, fio: str, birth_year: str) -> None:
+        self.search_form.search(fio, birth_year)
+
+    def should_have_results(self) -> None:
+        self.search_form.results_table.should_have_records()

--- a/tests/e2e_tests/test_clients_search.py
+++ b/tests/e2e_tests/test_clients_search.py
@@ -2,6 +2,7 @@ import pytest
 import allure
 
 from tests.base_test import BaseTest
+from core.ui.pages.clients_page import ClientsPage
 
 
 @allure.epic("Clients")
@@ -14,16 +15,7 @@ class TestClientsSearch(BaseTest):
     @allure.description("Opens clients page, fills search form and verifies that search returns at least one record")
     @allure.tag("E2E", "UI", "Positive")
     def test_search_clients(self):
-        page = self.browser.new_page()
-        url = "https://stage-frontend-arm-ui.apps.stg-okd-lan.vsk.ru/clients"
-        page.goto(url)
-        if "clients" not in page.url:
-            page.wait_for_url("**/clients", timeout=120000)
-        page.get_by_label("ФИО").fill("Тест Тестов")
-        page.get_by_label("Год рождения").fill("2000")
-        #page.get_by_placeholder("Выберите статус").click()
-        #page.get_by_role("option").first().click()
-        page.get_by_role("button", name="Поиск", exact=True).click()
-        page.locator("tbody tr[tuitr]").first.wait_for(timeout=5000)
-        rows = page.locator("tbody tr[tuitr]")
-        assert rows.count() > 0
+        clients_page = ClientsPage(self.browser.new_page())
+        clients_page.open()
+        clients_page.search_clients("Тест Тестов", "2000")
+        clients_page.should_have_results()


### PR DESCRIPTION
## Summary
- add base UI module class
- implement input, button and table elements
- add clients search form module and page
- rewrite client search test to use page object operations
- fix BasePage.open to assert title on the page instance

## Testing
- `pytest tests/e2e_tests/test_clients_search.py::TestClientsSearch::test_search_clients -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1155/chrome-linux/chrome)*
- `playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b060551628832987e263aec8fb9414